### PR TITLE
Remove react-scripts as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "peerDependencies": {
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
-    "react-scripts": "^5.0.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.4",


### PR DESCRIPTION
Remove react-scripts as a peerDependency as it shouldn't be required as a peer-dep.
Resolves #20
