### PR TITLE
Fix Typo in README [How to Use.md]

### DIFF
--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -13,7 +13,7 @@ import TawkMessengerReact from '@tawk.to/tawk-messenger-react';
 function App() {
     const tawkMessengerRef = useRef();
 
-    const handleMinimize () => {
+    const handleMinimize = () => {
         tawkMessengerRef.current.minimize();
     };
 


### PR DESCRIPTION
This pull request addresses a typo found in the How to Use.md

The typo is located at line 16 in the description of the `handleMinimize` function. This pull request aims to correct this to ensure accurate documentation and ease of use for future developers.

Please review the changes and merge them if they are satisfactory. Thank you.
