### PR TITLE
Fix another Typo in README [How to Use.md]

### DIFF
--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -1,8 +1,10 @@
 # How to Use
+
 Here are the basic of how to use callbacks and expose functions from the plugin. You can see the
 list of APIs in this [API reference](api-reference.md).
 
 ## Expose functions
+
 To access the expose functions, you will need to use **useRef** from react. Create a constant
 variable that will hold the **useRef()** and pass it in **TawkMessengerReact** component as a prop.
 
@@ -24,29 +26,30 @@ function App() {
             <TawkMessengerReact
                 propertyId="property_id"
                 widgetId="default"
-                useRef={tawkMessengerRef}/>
+                ref={tawkMessengerRef}/>
         </div>
     );
 }
 ```
 
 ## Using Callbacks
+
 Using the API callbacks, pass a function as props on the callback you will used.
 
 ```js
 function App() {
-    const onLoad = () => {
-        console.log('onLoad works!');
-    };
+  const onLoad = () => {
+    console.log('onLoad works!');
+  };
 
-    return (
-        <div className="App">
-            <TawkMessengerReact
-                propertyId="property_id"
-                widgetId="default"
-                onLoad={onLoad}/>
-        </div>
-    );
+  return (
+    <div className="App">
+      <TawkMessengerReact
+        propertyId="property_id"
+        widgetId="default"
+        onLoad={onLoad}
+      />
+    </div>
+  );
 }
 ```
-


### PR DESCRIPTION
Hi, 
Typo Correction in "How to Use.md" - Line 29

I found a small typo in the "How to Use.md" file. On line 29, useRef is mentioned, but it should be ref instead. I've corrected this in the pull request. Thanks